### PR TITLE
upgrade litedb to 4.0.0

### DIFF
--- a/source/LiteDbExplorer/LiteDbExplorer.csproj
+++ b/source/LiteDbExplorer/LiteDbExplorer.csproj
@@ -40,8 +40,8 @@
     <ApplicationIcon>Images\icon.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="LiteDB, Version=3.1.0.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
-      <HintPath>..\packages\LiteDB.3.1.0\lib\net35\LiteDB.dll</HintPath>
+    <Reference Include="LiteDB, Version=4.0.0.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
+      <HintPath>..\packages\LiteDB.4.0.0\lib\net40\LiteDB.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAPICodePack, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAPICodePack.Core.1.1.0\lib\Microsoft.WindowsAPICodePack.dll</HintPath>
@@ -188,7 +188,9 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/source/LiteDbExplorer/Windows/DocumentViewer.xaml
+++ b/source/LiteDbExplorer/Windows/DocumentViewer.xaml
@@ -10,7 +10,7 @@
         mc:Ignorable="d"
         Title="Document Editor" Width="600" Height="600" 
         WindowStartupLocation="CenterOwner"
-        Activated="Window_Activated" Closed="Window_Closed">
+        Activated="Window_Activated">
 
     <Window.Resources>
         <converters:InvertableBooleanToVisibilityConverter x:Key="InvertableBooleanToVisibilityConverter" />

--- a/source/LiteDbExplorer/Windows/DocumentViewer.xaml.cs
+++ b/source/LiteDbExplorer/Windows/DocumentViewer.xaml.cs
@@ -69,7 +69,6 @@ namespace LiteDbExplorer.Windows
 
         private BsonDocument currentDocument;
         private DocumentReference documentReference;
-        private LiteTransaction dbTrans;
 
         private bool isReadOnly = false;
         public bool IsReadOnly
@@ -116,12 +115,6 @@ namespace LiteDbExplorer.Windows
 
         private void LoadDocument(DocumentReference document)
         {
-            if (dbTrans != null)
-            {
-                dbTrans.Rollback();
-                dbTrans.Dispose();
-            }
-
             if (document.Collection is FileCollectionReference)
             {
                 var fileInfo = (document.Collection as FileCollectionReference).GetFileObject(document);
@@ -131,7 +124,6 @@ namespace LiteDbExplorer.Windows
 
             currentDocument = document.Collection.LiteCollection.FindById(document.LiteDocument["_id"]);
             documentReference = document;
-            dbTrans = documentReference.Collection.Database.LiteDatabase.BeginTrans();
             customControls = new ObservableCollection<DocumentFieldData>();
 
             for (int i = 0; i < document.LiteDocument.Keys.Count; i++)
@@ -159,11 +151,6 @@ namespace LiteDbExplorer.Windows
 
         private void ButtonCancel_Click(object sender, RoutedEventArgs e)
         {
-            if (dbTrans != null)
-            {
-                dbTrans.Rollback();
-            }
-
             DialogResult = false;
             Close();            
         }
@@ -193,7 +180,6 @@ namespace LiteDbExplorer.Windows
             {
                 documentReference.LiteDocument = currentDocument;
                 documentReference.Collection.UpdateItem(documentReference);
-                dbTrans.Commit();
             }
 
             DialogResult = true;
@@ -269,14 +255,6 @@ namespace LiteDbExplorer.Windows
         private void Window_Activated(object sender, EventArgs e)
         {
             ItemsField_SizeChanged(ListItems, null);
-        }
-
-        private void Window_Closed(object sender, EventArgs e)
-        {
-            if (dbTrans != null)
-            {
-                dbTrans.Dispose();
-            }
         }
 
         private void NextItemCommand_CanExecute(object sender, CanExecuteRoutedEventArgs e)

--- a/source/LiteDbExplorer/packages.config
+++ b/source/LiteDbExplorer/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Extended.Wpf.Toolkit" version="3.0" targetFramework="net452" />
-  <package id="LiteDB" version="3.1.0" targetFramework="net452" />
+  <package id="LiteDB" version="4.0.0" targetFramework="net452" />
   <package id="Microsoft.WindowsAPICodePack.Core" version="1.1.0" targetFramework="net452" />
   <package id="Microsoft.WindowsAPICodePack.Shell" version="1.1.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />


### PR DESCRIPTION
updated the litedb nuget package to 4.0.0 and removed all usages of [Transactions](https://github.com/mbdavid/LiteDB/wiki/Changelog#break-changes).  DocumentViewer works again after this.