### PR TITLE
Changed settings.json and recentfiles.txt to use AppData directory

### DIFF
--- a/source/LiteDbExplorer/Config.cs
+++ b/source/LiteDbExplorer/Config.cs
@@ -69,10 +69,10 @@ namespace LiteDbExplorer
 #endif
             var fileTarget = new FileTarget()
             {
-                FileName = Path.Combine(Paths.ProgramFolder, "explorer.log"),
+                FileName = Path.Combine(Paths.AppDataPath, "explorer.log"),
                 Layout = "${longdate}|${level:uppercase=true}:${message}${exception:format=toString}",
                 KeepFileOpen = false,
-                ArchiveFileName = Path.Combine(Paths.ProgramFolder, "explorer.{#####}.log"),
+                ArchiveFileName = Path.Combine(Paths.AppDataPath, "explorer.{#####}.log"),
                 ArchiveAboveSize = 4096000,
                 ArchiveNumbering = ArchiveNumberingMode.Sequence,
                 MaxArchiveFiles = 2

--- a/source/LiteDbExplorer/Paths.cs
+++ b/source/LiteDbExplorer/Paths.cs
@@ -11,6 +11,17 @@ namespace LiteDbExplorer
 {
     public class Paths : INotifyPropertyChanged
     {
+        public static string AppDataPath
+        {
+            get
+            {
+                var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "LiteDbExplorer");
+                if (!Directory.Exists(path))
+                    Directory.CreateDirectory(path);
+                return path;
+            }
+        }
+
         public static string ProgramFolder
         {
             get
@@ -31,7 +42,7 @@ namespace LiteDbExplorer
         {
             get
             {
-                return Path.Combine(ProgramFolder, "recentfiles.txt");
+                return Path.Combine(AppDataPath, "recentfiles.txt");
             }
         }
 
@@ -39,7 +50,7 @@ namespace LiteDbExplorer
         {
             get
             {
-                return Path.Combine(ProgramFolder, "settings.json");
+                return Path.Combine(AppDataPath, "settings.json");
             }
         }
 


### PR DESCRIPTION
Fixes an issue where application must be running as administrator when installed to Program Files directory (directory write permissions)
Also allows settings/recent-files to work per-user rather than machine-wide settings.
As per issue #30 , #17 , #25 